### PR TITLE
Use new forWindows define

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ datafiles = \
 	LICENSE.txt \
 	README.txt
 
-ifeq ($(uname), MINGW)
+define forWindows
   ldlibs = -lwsock32
-endif
+endef
 
 # This Makefile is based on the Makefile from pd-lib-builder written by
 # Katja Vetter. You can get it from:

--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -1,4 +1,4 @@
-# Makefile.pdlibbuilder version 0.1.0, dated 2015-12-08
+# Makefile.pdlibbuilder version 0.2.0, dated 2015-12-19
 #
 # Helper makefile for Pure Data external libraries.
 # Written by Katja Vetter March-June 2015 for the public domain. No warranties.
@@ -65,6 +65,13 @@
 # - makefiles
 # - makefiledirs
 # - externalsdir
+#
+# Optional multiline defines evaluated per operating system:
+#
+# - forLinux
+# - forDarwin
+# - forWindows
+#
 #
 # Variables avaialable for (re)definition via command arguments:
 #
@@ -139,6 +146,13 @@
 # any other centralized build layout for multiple libraries. Default value
 # is '..', meaning the direct parent. The value is used in search paths for 
 # pd core components (header files, and executable in the case of Windows).
+#
+# forLinux, forDarwin, forWindows:
+# Shorthand for 'variable definitions for Linux only' etc. Use like:
+#    define forLinux
+#      cflags += -DLINUX
+#      class.sources += linuxthing.c
+#    endef
 #
 # makefiles and makefiledirs: 
 # Extra makefiles or directories with makefiles that should be made in sub-make
@@ -430,20 +444,25 @@ endif
 
 
 # The following systems are defined: Linux, Darwin, Windows. GNU and
-# GNU/kFreeBSD are treated as Linux to get the same options. 
+# GNU/kFreeBSD are treated as Linux to get the same options. System-specific
+# multiline defines (optionally set in library makefile) are conditionally
+# evaluated here.
 
 uname := $(shell uname)
 
 ifeq ($(findstring $(uname), Linux GNU GNU/kFreeBSD), $(uname))
   system = Linux
+  $(eval $(forLinux))
 endif
 
 ifeq ($(uname), Darwin)
   system = Darwin
+  $(eval $(forDarwin))
 endif
 
 ifeq ($(findstring MINGW, $(uname)), MINGW)
   system = Windows
+  $(eval $(forWindows))
 endif
 
 # TODO: Cygwin, Android
@@ -691,7 +710,7 @@ MAKEFLAGS += --no-builtin-rules
 
 .PRECIOUS:
 .SUFFIXES:
-.PHONY: all pre post build-classes build-lib \
+.PHONY: all pre post build-lib \
         $(classes) $(makefiledirs) $(makefiles) \
         install install-executables install-datafiles install-datadirs \
         force clean vars allvars depend help
@@ -856,7 +875,7 @@ $(foreach v, $(classes), $(eval $(declare-class-executable-target)))
 # prerequisites rules so we do not evaluate them in that case.
 
 ifndef pdincludepathwithspaces
-  must-build-everything := $(filter all default lib, $(goals))
+  must-build-everything := $(filter all, $(goals))
   must-build-class := $(filter $(classes), $(goals))
   must-build-sources := $(foreach v, $(must-build-class), $($v.class.sources))
 endif


### PR DESCRIPTION
pd-lib-builder recently introduced new defines for platform specific flags. The proposed branch uses that instead of the current kludge that probably works only in one tested case. 
